### PR TITLE
쿠키 유효시간 설정 제거

### DIFF
--- a/server/src/interceptors/set-cookie.interceptor.ts
+++ b/server/src/interceptors/set-cookie.interceptor.ts
@@ -9,15 +9,11 @@ import { GqlExecutionContext } from '@nestjs/graphql';
 import { FastifyReply } from 'fastify';
 import { catchError, concatMap, map, Observable, of, tap } from 'rxjs';
 import { SessionService } from 'src/services';
-import { SessionConfig } from 'src/types/config';
 
 // https://stackoverflow.com/questions/63195571/unable-to-set-cookie-in-nestjs-graphql
 @Injectable()
 export class SetCookieInterceptor implements NestInterceptor {
-  constructor(
-    private sessionService: SessionService,
-    private configService: ConfigService,
-  ) {}
+  constructor(private sessionService: SessionService) {}
 
   intercept(
     context: ExecutionContext,
@@ -33,13 +29,7 @@ export class SetCookieInterceptor implements NestInterceptor {
         // naverSignIn mutation이 유저 정보를 반환하면 session setup
         const ctx = GqlExecutionContext.create(context);
         const { request } = ctx.getContext();
-        const {
-          session,
-          sessionStore,
-          raw: {
-            headers: { timestamp },
-          },
-        } = request;
+        const { session, sessionStore } = request;
         const { sessionId, cookie } = session;
         session.user = userInfoFromDB;
 
@@ -52,13 +42,7 @@ export class SetCookieInterceptor implements NestInterceptor {
             tap(() => {
               const reply: FastifyReply = ctx.getContext().reply;
 
-              const sessionDuration =
-                this.configService.get<SessionConfig>('session.duration');
-
-              reply.setCookie('JSESSIONID', sessionId, {
-                ...cookie,
-                expires: timestamp + sessionDuration,
-              });
+              reply.setCookie('JSESSIONID', sessionId, cookie);
 
               this.sessionService.setExpires({
                 sessionId,


### PR DESCRIPTION
- 클라이언트의 요청 시간으로부터 유효 시간을 카운트하는 것이 바람직한데,
- 서버의 timezone이 달라서인지 적용에 어려움이 있음
- 이미 세션에서 유효 시간을 설정하고 있으므로 쿠키가 만료되지 않아도 문제는 없다고 판단