### PR TITLE
로드밸런서의 비용이 생각보다 커서 단일 서버로 돌리기로 결정

### DIFF
--- a/server/src/main.ts
+++ b/server/src/main.ts
@@ -12,19 +12,19 @@ import { join } from 'path';
 import * as fs from 'fs';
 
 async function bootstrap() {
-  // const httpsOptions =
-  //   process.env.NODE_ENV === 'development'
-  //     ? null
-  //     : {
-  //         key: fs.readFileSync(process.env.KEY),
-  //         cert: fs.readFileSync(process.env.CERT),
-  //       };
+  const httpsOptions =
+    process.env.NODE_ENV === 'development'
+      ? null
+      : {
+          key: fs.readFileSync(process.env.KEY),
+          cert: fs.readFileSync(process.env.CERT),
+        };
 
   const app = await NestFactory.create<NestFastifyApplication>(
     AppModule,
     new FastifyAdapter({
       logger: false,
-      // https: httpsOptions,
+      https: httpsOptions,
     }),
   );
 


### PR DESCRIPTION
- 단일 서버로 돌릴 경우 ssl 인증서를 해당 서버에서 처리해야 하므로